### PR TITLE
Fix hardcoded expectation result

### DIFF
--- a/Source/Spry/Matchers/beGreaterThan.swift
+++ b/Source/Spry/Matchers/beGreaterThan.swift
@@ -12,6 +12,6 @@ public func beGreaterThan<T: Comparable>(_ expectedValue: T?) -> Matcher<T> {
 
 /// A Nimble matcher that succeeds when the actual value is greater than the expected value.
 @discardableResult
-public func ><T: Comparable>(lhs: Expectation<T>, rhs: T) -> Color {
+public func ><T: Comparable>(lhs: Expectation<T>, rhs: T) -> ExpectationResult {
     return lhs.to(beGreaterThan(rhs))
 }

--- a/Source/Spry/Matchers/beGreaterThanOrEqualTo.swift
+++ b/Source/Spry/Matchers/beGreaterThanOrEqualTo.swift
@@ -15,6 +15,6 @@ public func beGreaterThanOrEqualTo<T: Comparable>(_ expectedValue: T?) -> Matche
 /// A Nimble matcher that succeeds when the actual value is greater than
 /// or equal to the expected value.
 @discardableResult
-public func >=<T: Comparable>(lhs: Expectation<T>, rhs: T) -> Color {
+public func >=<T: Comparable>(lhs: Expectation<T>, rhs: T) -> ExpectationResult {
     return lhs.to(beGreaterThanOrEqualTo(rhs))
 }

--- a/Source/Spry/Matchers/beLessThanOrEqual.swift
+++ b/Source/Spry/Matchers/beLessThanOrEqual.swift
@@ -14,6 +14,6 @@ public func beLessThanOrEqualTo<T: Comparable>(_ expectedValue: T?) -> Matcher<T
 /// A Nimble matcher that succeeds when the actual value is less than
 /// or equal to the expected value.
 @discardableResult
-public func <=<T: Comparable>(lhs: Expectation<T>, rhs: T) -> Color {
+public func <=<T: Comparable>(lhs: Expectation<T>, rhs: T) -> ExpectationResult {
     return lhs.to(beLessThanOrEqualTo(rhs))
 }


### PR DESCRIPTION
 - What behavior was changed?
`beGreaterThan`, `beGreaterThanOrEqualTo`, and `beLessThanOrEqual` have hardcoded expectation result, which results in an error if the type of `ExpectationResult` changes.
 - What code was refactored / updated to support this change?
The files corresponding to each matcher.
 - What issues are related to this PR? Or why was this change introduced?
Tried replacing type of `ExpectationResult` to `String` since colors don't show preview in my Xcode (Xcode 8.3).

 - [ ] Does this have tests?
Can't create a test since the type of ExpectationResult is set at compile time.
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?
